### PR TITLE
Sync with upstream to pull in API version check

### DIFF
--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -47,7 +47,7 @@ function createServerFromBaseUri (raml, options) {
   var app = osprey.Router()
   var path = (raml.baseUri || '').replace(/^(\w+:)?\/\/[^\/]+/, '') || '/'
 
-  app.use(path, createServer(raml, options))
+  app.use(path, raml.baseUriParameters, createServer(raml, options))
 
   return app
 }

--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -1,6 +1,6 @@
-var router = require('osprey-router')
 var Negotiator = require('negotiator')
 var resources = require('osprey-resources')
+var osprey = require('osprey')
 
 /**
  * Export the mock server.
@@ -28,10 +28,9 @@ function ospreyMockServer (raml) {
  * @return {Function}
  */
 function createServer (raml, options) {
-  var osprey = require('osprey')
-  var app = router()
+  var app = osprey.Router()
 
-  app.use(osprey.createServer(raml, options))
+  app.use(osprey.server(raml, options))
   app.use(ospreyMockServer(raml))
 
   return app
@@ -45,7 +44,7 @@ function createServer (raml, options) {
  * @return {Function}
  */
 function createServerFromBaseUri (raml, options) {
-  var app = router()
+  var app = osprey.Router()
   var path = (raml.baseUri || '').replace(/^(\w+:)?\/\/[^\/]+/, '') || '/'
 
   app.use(path, createServer(raml, options))

--- a/package.json
+++ b/package.json
@@ -36,18 +36,18 @@
   },
   "homepage": "https://github.com/mulesoft-labs/osprey-mock-service",
   "devDependencies": {
-    "chai": "^2.1.1",
+    "chai": "^3.0.0",
     "istanbul": "^0.3.5",
     "mocha": "^2.1.0",
     "pre-commit": "^1.0.1",
-    "standard": "^3.1.2"
+    "standard": "^4.5.2"
   },
   "dependencies": {
-    "finalhandler": "^0.3.4",
+    "finalhandler": "^0.4.0",
     "negotiator": "^0.5.1",
     "osprey": "^0.2.0-alpha",
     "osprey-resources": "^0.3.0",
-    "osprey-router": "^0.0.5",
+    "osprey-router": "^0.1.0",
     "raml-parser": "^0.8.10",
     "yargs": "^3.5.4"
   }

--- a/package.json
+++ b/package.json
@@ -45,9 +45,8 @@
   "dependencies": {
     "finalhandler": "^0.4.0",
     "negotiator": "^0.5.1",
-    "osprey": "^0.2.0-alpha",
+    "osprey": "^0.2.0-beta.3",
     "osprey-resources": "^0.3.0",
-    "osprey-router": "^0.1.0",
     "raml-parser": "^0.8.10",
     "yargs": "^3.5.4"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey-mock-service",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Generate an API mock service from a RAML definition using Osprey",
   "main": "osprey-mock-service.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "finalhandler": "^0.3.4",
     "negotiator": "^0.5.1",
     "osprey": "^0.2.0-alpha",
+    "osprey-resources": "^0.3.0",
     "osprey-router": "^0.0.5",
     "raml-parser": "^0.8.10",
     "yargs": "^3.5.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey-mock-service",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Generate an API mock service from a RAML definition using Osprey",
   "main": "osprey-mock-service.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey-mock-service",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Generate an API mock service from a RAML definition using Osprey",
   "main": "osprey-mock-service.js",
   "files": [


### PR DESCRIPTION
The mock API used to accept any API version in the URL; now it only
accepts the specified one.
